### PR TITLE
fix: image 组件 showMenuByLongpress 失效问题

### DIFF
--- a/uni_modules/uv-image/components/uv-image/uv-image.vue
+++ b/uni_modules/uv-image/components/uv-image/uv-image.vue
@@ -19,7 +19,7 @@
 				:mode="mode"
 				@error="onErrorHandler"
 				@load="onLoadHandler"
-				:show-menuv-by-longpress="showMenuByLongpress"
+				:show-menu-by-longpress="showMenuByLongpress"
 				:lazy-load="lazyLoad"
 				class="uv-image__image"
 				:style="[imageStyle]"


### PR DESCRIPTION
show-menu-by-longpress 拼写错误导致该参数在小程序不起作用