### PR TITLE
uv-album存在调用拼写错误

### DIFF
--- a/uni_modules/uv-album/components/uv-album/uv-album.vue
+++ b/uni_modules/uv-album/components/uv-album/uv-album.vue
@@ -268,7 +268,7 @@
 				// 延时一定时间，以获取dom尺寸
 				await this.$uv.sleep(30)
 				// #ifndef APP-NVUE
-				this.$uGetRect('.uv-album__row').then((size) => {
+				this.$uvGetRect('.uv-album__row').then((size) => {
 					this.singleWidth = size.width * this.singlePercent
 				})
 				// #endif


### PR DESCRIPTION
原组件存在拼写错误，会提示方法不存在。
将this.$uGetRect 改为 this.$uvGetRect 即可修复。