### PR TITLE
fix(picker): 修复 uv-picker 多级联动的bug

### DIFF
--- a/uni_modules/uv-picker/components/uv-picker/uv-picker.vue
+++ b/uni_modules/uv-picker/components/uv-picker/uv-picker.vue
@@ -234,6 +234,8 @@ export default {
 		setColumnValues(columnIndex, values) {
 			// 替换innerColumns数组中columnIndex索引的值为values，使用的是数组的splice方法
 			this.innerColumns.splice(columnIndex, 1, values)
+			// 替换完成之后将修改列之后的已选值置空
+			this.setLastIndex(this.innerIndex.slice(0,columnIndex))
 			// 拷贝一份原有的innerIndex做临时变量，将大于当前变化列的所有的列的默认索引设置为0
 			let tmpIndex = this.$uv.deepClone(this.innerIndex)
 			for (let i = 0; i < this.innerColumns.length; i++) {


### PR DESCRIPTION
修复如下问题：
打开 https://www.uvui.cn/components/picker.html ，在右边手机界面里点击“多列联动”，第二列选择“厦门”，然后第一列选择“美国”，然后第二列选择“华盛顿”，这时第二列的数据会变成“深圳、厦门、上海...”
#18 
#36 
-- 2025-03-28