### PR TITLE
feat: 小优化思路参考，当点击处于open状态的swipe-item，会同时触发slot处的click，应该当所有的item状态均处于…

### DIFF
--- a/uni_modules/uv-swipe-action/components/uv-swipe-action-item/index.wxs
+++ b/uni_modules/uv-swipe-action/components/uv-swipe-action-item/index.wxs
@@ -18,7 +18,6 @@ function touchstart(event, ownerInstance) {
 	// 记录触摸开始点的坐标值
 	state.startX = touches[0].pageX
 	state.startY = touches[0].pageY
-	
 	ownerInstance.callMethod('closeOther')
 }
 
@@ -153,7 +152,7 @@ function openSwipeAction(instance, ownerInstance) {
 function setStatus(status, instance, ownerInstance) {
 	var state = instance.getState()
 	state.status = status
-	ownerInstance.callMethod('setState', status)
+	ownerInstance.callMethod('statusChangeHandler', status)
 }
 
 // 一次性收起滑动菜单

--- a/uni_modules/uv-swipe-action/components/uv-swipe-action-item/wxs.js
+++ b/uni_modules/uv-swipe-action/components/uv-swipe-action-item/wxs.js
@@ -4,12 +4,20 @@ export default {
         closeHandler() {
             this.status = 'close'
         },
-        setState(status) {
-            this.status = status
-        },
         closeOther() {
             // 尝试关闭其他打开的单元格
             this.parent && this.parent.closeOther(this)
-        }
+        },
+        statusChangeHandler(status) {
+            if (status === this.status) return // 没有变化
+            this.$emit('statusChange', {
+                fromStatus: this.status,
+                toStatus: status,
+                index: this.name
+            })
+            this.status = status
+            // 维护开启状态的单元格列表
+            this.parent && this.parent.handleOpenedCells(this, status, this.name)
+        },
     }
 }

--- a/uni_modules/uv-swipe-action/components/uv-swipe-action/uv-swipe-action.vue
+++ b/uni_modules/uv-swipe-action/components/uv-swipe-action/uv-swipe-action.vue
@@ -20,7 +20,10 @@
 		name: 'uv-swipe-action',
 		mixins: [mpMixin, mixin, props],
 		data() {
-			return {}
+			return {
+        openedCellItem: [],
+        itemsCanClick: true
+      }
 		},
 		provide() {
 			return {
@@ -50,16 +53,44 @@
 			this.children = []
 		},
 		methods: {
-			closeOther(child) {
-				if (this.autoClose) {
-					// 历遍所有的单元格，找出非当前操作中的单元格，进行关闭
-					this.children.map((item, index) => {
-						if (child !== item) {
-							item.closeHandler()
-						}
-					})
-				}
-			}
+      closeOther(child) {
+        this.itemsCanClick = this.computeClickStatus()
+        if (this.autoClose) {
+          // 历遍所有的单元格，找出非当前操作中的单元格，进行关闭
+          this.openedCellItem.map((item, index) => {
+            if (item !== child)
+              item.statusChangeHandler('close')
+          })
+        }
+      },
+      computeClickStatus(name) {
+        let openedCellIds = this.openedCells()
+        // autoClose为true，只会有一个cell处于打开状态
+        if (this.openedCellItem.length !== 0 && !openedCellIds.includes(name)) return false
+        if (this.openedCellItem.length !== 0 && openedCellIds.includes(name)) {
+          // 关闭这个打开的cell
+          this.closeByName(name)
+          return false
+        }
+        return true
+      },
+      itemsClickStatus() {
+        return this.itemsCanClick
+      },
+      openedCells() {
+        let openedCellList = []
+        this.openedCellItem.forEach(item => openedCellList.push(item.name))
+        return openedCellList
+      },
+      handleOpenedCells(child, status, name) {
+        // open添加，close移除，如果有的话
+        let childIndex = this.openedCellItem.indexOf(child)
+        if (status === 'open' && childIndex === -1) {
+          this.openedCellItem.push(child)
+        } else if (status === 'close' && childIndex !== -1) {
+          this.openedCellItem.splice(childIndex, 1)
+        }
+      }
 		}
 	}
 </script>


### PR DESCRIPTION
可以考虑优化一下swipe-action组件，小优化思路参考，当点击处于open状态的swipe-item，会同时触发slot处的click，应该当所有的item状态均处于终态close时，再次点击触发click事件。touchstart会遍历每一个child的close方法，加入open状态管理，仅调用处于open状态的item。
效果：
![20250724-174046](https://github.com/user-attachments/assets/3fe62546-b72a-4811-a24f-8dcb0523c011)
参考代码：
`<uv-swipe-action ref="swipeAction" :autoClose="true">
    <uv-swipe-action-item @click="handleOption" :options="options" v-for="item in 8" :key="item" :name="item">
         <msg-card @click="onItemClick(item)"></msg-card>
    </uv-swipe-action-item>
</uv-swipe-action>`

`onItemClick(index) {
// 列表中的cell全部处于close终态时返回true，详情可见组件内代码
    if (!this.$refs.swipeAction.itemsClickStatus()) return
    console.log('item click', '----', Date.now());
}`

